### PR TITLE
Support for one-way data binding, cancelLabel, removeDropdownOnDestroy

### DIFF
--- a/app/components/date-range-picker.js
+++ b/app/components/date-range-picker.js
@@ -33,6 +33,8 @@ export default Ember.Component.extend({
   },
   removeDropdownOnDestroy: false,
   cancelLabel: 'Clear',
+  applyAction: null,
+  cancelAction: null,
 
   //Init the dropdown when the component is added to the DOM
   didInsertElement: function() {
@@ -56,13 +58,34 @@ export default Ember.Component.extend({
       opens: this.get('opens')
     });
     this.$('.daterangepicker-input').on('apply.daterangepicker', function(ev, picker) {
-      self.set('start', picker.startDate.format(self.get('serverFormat')));
-      self.set('end', picker.endDate.format(self.get('serverFormat')));
+      var start = picker.startDate.format(self.get('serverFormat'));
+      var end = picker.endDate.format(self.get('serverFormat'));
+      var applyAction = self.get('applyAction');
+
+      if (applyAction) {
+        Ember.assert(
+          'applyAction for date-range-picker must be a function',
+          typeof applyAction === 'function'
+        );
+        applyAction(start, end);
+      } else {
+        self.setProperties({start, end});
+      }
     });
 
     this.$('.daterangepicker-input').on('cancel.daterangepicker', function() {
-      self.set('start', undefined);
-      self.set('end', undefined);
+      var cancelAction = self.get('cancelAction');
+
+      if (cancelAction) {
+        Ember.assert(
+          'cancelAction for date-range-picker must be a function',
+          typeof cancelAction === 'function'
+        );
+        cancelAction();
+      } else {
+        self.set('start', undefined);
+        self.set('end', undefined);
+      }
     });
 
     this.$('.daterangepicker-input').on('show.daterangepicker', function(ev, picker) {

--- a/app/components/date-range-picker.js
+++ b/app/components/date-range-picker.js
@@ -31,6 +31,8 @@ export default Ember.Component.extend({
     'This Month': [moment().startOf('month'), moment().endOf('month')],
     'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
   },
+  removeDropdownOnDestroy: false,
+  cancelLabel: 'Clear',
 
   //Init the dropdown when the component is added to the DOM
   didInsertElement: function() {
@@ -38,7 +40,7 @@ export default Ember.Component.extend({
 
     this.$('.daterangepicker-input').daterangepicker({
       locale: {
-        cancelLabel: 'Clear'
+        cancelLabel: this.get('cancelLabel')
       },
       format: this.get('format'),
       startDate: this.get('start'),
@@ -71,6 +73,8 @@ export default Ember.Component.extend({
 
   //Remove the hidden dropdown when this component is destroyed
   willDestroy: function () {
-    $('.daterangepicker').remove();
+    if (this.get('removeDropdownOnDestroy')) {
+      Ember.$('.daterangepicker').remove();
+    }
   }
 });


### PR DESCRIPTION
* Added support for one-way data binding via `applyAction` and `cancelAction` callbacks. If the callback is provided, it is called instead mutating `start`/`end` properties directly.
* Added `cancelLabel` property that defaults to **'Clear'**
* Added `removeDropdownOnDestroy` flag that defaults to `false`.

I'm not sure why you removing **.daterangepicker** hidden dropdown menu from the DOM. AFAIK it is added there only once, when DOM is ready. Thus, when you remove it and transition between routes, datepicker is not working anymore, since the hidden menu is gone. I moved it under the flag, but I guess you could get rid of the whole `willDestroy` event altogether.