### PR TITLE
Add serverFormat attributeBinding parameter.

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,8 @@ var Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('with-params');
+  this.route('without-params');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/with-params.js
+++ b/tests/dummy/app/routes/with-params.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+});

--- a/tests/dummy/app/routes/without-params.js
+++ b/tests/dummy/app/routes/without-params.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,8 +1,7 @@
-<h2 id="title">Welcome to Ember.js</h2>
-
-<div>
-  {{date-range-picker}}
+<div class="container">
+  <h2 id="title">{{#link-to 'index'}}Welcome to Ember.js{{/link-to}}</h2>
+  {{link-to 'With-Params' 'with-params'}} |
+  {{link-to 'Without-Params' 'without-params'}}
+  <hr>
+  {{outlet}}
 </div>
-
-
-{{outlet}}

--- a/tests/dummy/app/templates/with-params.hbs
+++ b/tests/dummy/app/templates/with-params.hbs
@@ -1,0 +1,5 @@
+
+<h4>With Params</h4>
+<div>
+  {{date-range-picker start="20140101" end="20141231" serverFormat="YYYYMMDD"}}
+</div>

--- a/tests/dummy/app/templates/without-params.hbs
+++ b/tests/dummy/app/templates/without-params.hbs
@@ -1,0 +1,6 @@
+
+<h4>Without Params</h4>
+<div>
+  {{date-range-picker}}
+</div>
+


### PR DESCRIPTION
In order to allow users to pass in different `serverFormat` arguments specific to their use cases, I have updated the `attributeBindings` array to include the `serverFormat` parameter.  The date picker can now be initialized as in the following ways:
*    `{{date-range-picker}} `
*    `{{date-range-picker start="2015-01-01" end="2015-07-10"}}`
*    `{{date-range-picker start="20150101" end="20159710" serverFormat="YYYYMMDD"}}`

If a user would like do use a different format, they can specify it as such.  However, the `serverFormat` argument MUST match the format defined in the `start` and `end` date arguments.

Other changes include disabling the observer in the `rangeText` computed property function.  This observer was allowing the main `rangeText` input field to become out of sync with the hidden `start` and `end` input fields when selecting a custom date range.  The user must now explicitly click the "Apply" button to reflect changes in a custom date range.

**[BUGFIX]**  Moment.js was logging the following error whenever we passed a moment object to the datepicker instance: `Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release`.  This has been fixed by supplying moment with the current date format we are asking it to parse.  For example:

    // will elicit a deprecation warning
    moment('2014-01-01').format();

    // what moment now expects
    moment('2014-01-01, 'YYYY-MM-DD').format();
     

**[FEATURE CHANGE]**  The "Clear" button could be called "Cancel", and  no longer escapes the values from the hidden `start` and `end` input form fields.  I propose this change on the basis that if a user is supplying initial start and end dates, then if they choses not to apply a new date range, them hitting the Clear/Cancel button should not erase the current values, but instead persist their initial state.