### PR TITLE
Update to the latest bootstrap-daterangepicker version. Rename css de…

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -58,9 +58,9 @@ export default Ember.Component.extend({
 
     this.$('.daterangepicker-input').daterangepicker({
       locale: {
-        cancelLabel: this.get('cancelLabel')
+        cancelLabel: this.get('cancelLabel'),
+        format: this.get('format')
       },
-      format: this.get('format'),
       startDate: startDate,
       endDate: endDate,
       minDate: minDate,

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
-    "bootstrap-daterangepicker": "~1.3.20",
+    "bootstrap-daterangepicker": "~2.0.11",
     "moment": ">= 2.8.0",
     "moment-timezone": ">= 0.1.0"
   }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,6 @@ module.exports = {
     this._super.included(app);
     this.app.import(app.bowerDirectory + '/moment/moment.js');
     this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.js');
-    this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker-bs3.css');
+    this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.css');
   }
 };


### PR DESCRIPTION
This PR upgrades this addon to use the latest version of the bootstrap-daterangepicker bower dependency.  This requires a change to the index.js css import file path as well.

@josemarluedke Thanks!