### PR TITLE
Added blueprint to install dependencies

### DIFF
--- a/blueprints/ember-cli-daterangepicker/index.js
+++ b/blueprints/ember-cli-daterangepicker/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addBowerPackagesToProject([
+      { name: 'bootstrap-daterangepicker', target: "~2.0.11" },
+      { name: 'moment', target: ">= 2.8.0" },
+      { name: 'moment-timezone', target: ">= 0.1.0" }
+    ]);
+  }
+};


### PR DESCRIPTION
I'm new to Ember, so I apologize if this isn't the "Ember way". I noticed that this addon wasn't installing dependencies as specified in the bower.json. I modeled this blueprint after other addons and tested the install using my repository's URL with `ember install <url>`.

I matched the target versions to the bower.json (though those can probably be updated as well).

Let me know if any additional changes are needed for you to accept this PR.

Thanks.