### PR TITLE
Fixing custom range support.

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -92,7 +92,7 @@ export default Ember.Component.extend({
       linkedCalendars: this.get('linkedCalendars')
     };
 
-    if (this.get('singleDatePicker') === undefined) {
+    if (!this.get('singleDatePicker')) {
       options.ranges = this.get('ranges');
     }
 


### PR DESCRIPTION
Check for `singleDatePicker` should check for boolean value, not `undefined`.

The component's default value for `singleDatePicker` is `false`, so the calling application was forced to pass in `singleDatePicker=undefined` in order to have custom ranges displayed.