### PR TITLE
Add parent element option

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -15,6 +15,7 @@ export default Ember.Component.extend({
   showWeekNumbers: false,
   showDropdowns: false,
   linkedCalendars: false,
+  parentEl: 'body',
 
   format: 'MMM D, YYYY',
   serverFormat: 'YYYY-MM-DD',
@@ -89,7 +90,8 @@ export default Ember.Component.extend({
       timePickerIncrement: this.get('timePickerIncrement'),
       showWeekNumbers: this.get('showWeekNumbers'),
       showDropdowns: this.get('showDropdowns'),
-      linkedCalendars: this.get('linkedCalendars')
+      linkedCalendars: this.get('linkedCalendars'),
+      parentEl: this.get('parentEl')
     };
 
     if (!this.get('singleDatePicker')) {


### PR DESCRIPTION
This PR adds the `parentEl` option that is described here: http://www.daterangepicker.com/#options. It's value defaults to `body` (https://github.com/dangrossman/bootstrap-daterangepicker/blob/master/daterangepicker.js#L40) but can be overriden using this optional param.