### PR TITLE
Move moment.js dependency to npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,6 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "bootstrap-daterangepicker": "~2.0.11",
-    "moment": ">= 2.8.0",
-    "moment-timezone": ">= 0.1.0"
+    "bootstrap-daterangepicker": "~2.0.11"
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ module.exports = {
   name: 'ember-cli-daterangepicker',
 
   included: function(app) {
-    this._super.included(app);
-    this.app.import(app.bowerDirectory + '/moment/moment.js');
+    this._super.included.apply(this, arguments);
     this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.js');
     this.app.import(app.bowerDirectory + '/bootstrap-daterangepicker/daterangepicker.css');
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-moment-shim": "0.6.2",
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.0.0",
@@ -43,7 +42,10 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-moment-shim": "^1.0.0",
+    "moment": "2.11.2",
+    "moment-timezone": "0.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
The [ember-cli-moment-shim](https://github.com/jasonmit/ember-cli-moment-shim) library recently moved from bower to npm for managing moment as a dependency. [Ember-moment](https://github.com/stefanpenner/ember-moment) relies on ember-cli-moment-shim for managing the moment.js dependency. I think we should do the same with this library. 

I ran into a problem previously with moment.js getting added twice in my asset pipeline (once by the daterangepicker via bower and then from ember-cli-moment-shim via npm).

This PR makes ember-cli-moment-shim and moment npm dependencies. Ember-cli-moment-shim takes care of adding moment.js to the vendor.js file when using this addon.
