### PR TITLE
Add test for autoUpdateInput parameter

### DIFF
--- a/tests/integration/components/date-range-picker-test.js
+++ b/tests/integration/components/date-range-picker-test.js
@@ -43,6 +43,18 @@ test('input renders with applyAction and cancelAction parameters', function (ass
   assert.equal(this.$('.daterangepicker-input').length, 1, 'did not render');
 });
 
+test('input renders empty with autoUpdateInput parameter', function (assert) {
+  assert.expect(1);
+
+  this.render(hbs `
+    {{date-range-picker
+      autoUpdateInput=false
+    }}
+  `);
+
+  assert.equal(this.$('.daterangepicker-input').val(), '', 'input is not empty');
+});
+
 test('dropdown menu renders', function (assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This test confirms that the initial input is empty when the `autoUpdateInput` parameter is set to false.