### PR TITLE
Fix range text issue when single date is true

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -24,11 +24,19 @@ export default Ember.Component.extend({
     let serverFormat = this.get('serverFormat');
     let start = this.get('start');
     let end = this.get('end');
-    if (!Ember.isEmpty(start) && !Ember.isEmpty(end)) {
-      return moment(start, serverFormat).format(format) + this.get('separator') +
-        moment(end, serverFormat).format(format);
+    if (this.get('singleDatePicker')) {
+      if (!Ember.isEmpty(start)) {
+        return moment(start, serverFormat).format(format);
+      } else {
+        return '';
+      }
+    } else {
+      if (!Ember.isEmpty(start) && !Ember.isEmpty(end)) {
+        return moment(start, serverFormat).format(format) + this.get('separator') + moment(end, serverFormat).format(format);
+      } else {
+        return '';
+      }
     }
-    return '';
   }),
   opens: null,
   drops: null,

--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -19,25 +19,49 @@ export default Ember.Component.extend({
 
   format: 'MMM D, YYYY',
   serverFormat: 'YYYY-MM-DD',
-  rangeText: Ember.computed('start', 'end', function() {
+
+  rangesChanged: Ember.observer('start', 'end', function() {
+    Ember.run.once(this, 'setRangeText');
+  }),
+
+  setRangeText() {
     let format = this.get('format');
     let serverFormat = this.get('serverFormat');
     let start = this.get('start');
     let end = this.get('end');
+    let rangeText = '';
     if (this.get('singleDatePicker')) {
       if (!Ember.isEmpty(start)) {
-        return moment(start, serverFormat).format(format);
-      } else {
-        return '';
+        rangeText = moment(start, serverFormat).format(format);
       }
     } else {
       if (!Ember.isEmpty(start) && !Ember.isEmpty(end)) {
         return moment(start, serverFormat).format(format) + this.get('separator') + moment(end, serverFormat).format(format);
-      } else {
-        return '';
       }
     }
-  }),
+    this.set('rangeText', rangeText);
+  },
+
+
+  // rangeText: Ember.computed('start', 'end', function() {
+  //   let format = this.get('format');
+  //   let serverFormat = this.get('serverFormat');
+  //   let start = this.get('start');
+  //   let end = this.get('end');
+  //   if (this.get('singleDatePicker')) {
+  //     if (!Ember.isEmpty(start)) {
+  //       return moment(start, serverFormat).format(format);
+  //     } else {
+  //       return '';
+  //     }
+  //   } else {
+  //     if (!Ember.isEmpty(start) && !Ember.isEmpty(end)) {
+  //       return moment(start, serverFormat).format(format) + this.get('separator') + moment(end, serverFormat).format(format);
+  //     } else {
+  //       return '';
+  //     }
+  //   }
+  // }),
   opens: null,
   drops: null,
   separator: ' - ',

--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -42,26 +42,6 @@ export default Ember.Component.extend({
     this.set('rangeText', rangeText);
   },
 
-
-  // rangeText: Ember.computed('start', 'end', function() {
-  //   let format = this.get('format');
-  //   let serverFormat = this.get('serverFormat');
-  //   let start = this.get('start');
-  //   let end = this.get('end');
-  //   if (this.get('singleDatePicker')) {
-  //     if (!Ember.isEmpty(start)) {
-  //       return moment(start, serverFormat).format(format);
-  //     } else {
-  //       return '';
-  //     }
-  //   } else {
-  //     if (!Ember.isEmpty(start) && !Ember.isEmpty(end)) {
-  //       return moment(start, serverFormat).format(format) + this.get('separator') + moment(end, serverFormat).format(format);
-  //     } else {
-  //       return '';
-  //     }
-  //   }
-  // }),
   opens: null,
   drops: null,
   separator: ' - ',


### PR DESCRIPTION
The options for getting a `initially empty single date picker` are `singleDatePicker: true`, and `autoUpdateInput: false`.
However, after a date being selected, the `rangeText` appears to be `startDate - endDate` format, which looks wrong since single date mode only use `start`.
This PR hides the `end` date value in `rangeText` when the `single date mode` is true.
No testing suite for this, but the fix works fine on my own machine.
