### PR TITLE
Remove moment related deps from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "bootstrap-daterangepicker": "^2.1.18",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "ember-cli-babel": "^5.1.5",
-    "ember-cli-moment-shim": "^1.0.0",
-    "moment": "2.11.2",
-    "moment-timezone": "0.5.0"
+    "ember-cli-babel": "^5.1.5"
+  },
+  "peerDependencies": {
+    "ember-cli-moment-shim": ">= 1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
#57 I removed `moment`, `moment-timezone` and `ember-cli-moment-shim` from `devDependencies` section in package.json, and added `ember-cli-moment-shim` to `peerDependencies` in package.json. I didn't add a blueprint, because we already have one that installs both of the three.
Please review the PR and correct me if any thing was wrong.