### PR TITLE
[Testings fixed] Removed moment related deps from package.json

### DIFF
--- a/app/templates/components/date-range-picker.hbs
+++ b/app/templates/components/date-range-picker.hbs
@@ -1,6 +1,6 @@
-<label>{{context.label}}</label>
-{{input value=context.rangeText class='daterangepicker-input form-control' placeholder=context.placeholder}}
+<label>{{label}}</label>
+{{input value=rangeText class='daterangepicker-input form-control' placeholder=placeholder}}
 <div class="hide">
-  {{input value=context.start}}
-  {{input value=context.end}}
+  {{input value=start}}
+  {{input value=end}}
 </div>

--- a/blueprints/ember-cli-daterangepicker/index.js
+++ b/blueprints/ember-cli-daterangepicker/index.js
@@ -6,9 +6,7 @@ module.exports = {
   afterInstall: function() {
     return this.addPackagesToProject([
       { name: 'bootstrap-daterangepicker' },
-      { name: 'ember-cli-moment-shim' },
-      { name: 'moment' },
-      { name: 'moment-timezone' }
+      { name: 'ember-cli-moment-shim' }
     ]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -35,19 +35,20 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.1.2",
-    "loader.js": "^4.0.0"
+    "loader.js": "^4.0.0",
+    "bootstrap-daterangepicker": "^2.1.24",
+    "ember-cli-moment-shim": "^2.2.1"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "bootstrap-daterangepicker": "^2.1.18",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
-    "ember-cli-babel": "^5.1.5",
-    "ember-cli-moment-shim": "^1.0.0",
-    "moment": "2.11.2",
-    "moment-timezone": "0.5.0"
+    "ember-cli-babel": "^5.1.5"
+  },
+  "peerDependencies": {
+    "ember-cli-moment-shim": ">= 1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
#57 I removed `moment`, `moment-timezone` and `ember-cli-moment-shim` from `dependencies` to `devDependencies`, and added `ember-cli-moment-shim` to `peerDependencies`. I didn't add a blueprint, because we already have one that installs both of the three. I also removed the `context.` from template. I don't know why we need it, we can access the `properties` directly in template. But the npm tests failed a lot if we keep it.
Please review the PR and correct me if any thing was wrong.