### PR TITLE
spread syntax ... is applicable only for iterables. 

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -200,7 +200,7 @@ export default Ember.Component.extend({
         `${actionName} for date-range-picker must be a function`,
         typeof action === 'function'
       );
-      this.sendAction(actionName, ...attrs);
+      this.sendAction(actionName, attrs, picker);
     } else {
       if (!this.isDestroyed) {
         this.setProperties(attrs);


### PR DESCRIPTION
So removed this `...` syntax and exposed `picker` object too for getting more details.

Fixes #66