### PR TITLE
Add option for custom template

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -75,6 +75,7 @@ export default Ember.Component.extend({
   firstDay: 0,
   isInvalidDate: noop,
   isCustomDate: noop,
+  customTemplate: null,
 
   // Init the dropdown when the component is added to the DOM
   didInsertElement() {
@@ -110,6 +111,7 @@ export default Ember.Component.extend({
     let maxDate = momentMaxDate.isValid() ? momentMaxDate : undefined;
 
     let showCustomRangeLabel = this.get('showCustomRangeLabel');
+    let customTemplate = this.get('customTemplate');
 
     let options = this.getProperties(
       'isInvalidDate',
@@ -132,7 +134,8 @@ export default Ember.Component.extend({
       'showCustomRangeLabel',
       'linkedCalendars',
       'dateLimit',
-      'parentEl'
+      'parentEl',
+      'customTemplate'
     );
 
     let localeOptions = this.getProperties(
@@ -155,6 +158,7 @@ export default Ember.Component.extend({
       endDate: endDate,
       minDate: minDate,
       maxDate: maxDate,
+      template: customTemplate
     };
 
     if (!this.get('singleDatePicker')) {


### PR DESCRIPTION
The bootstrap-datepicker library has an (undocumented?) option to replace the HTML template that it renders instead of the standard HTML. 

I needed to pass a different template, so I added this option. I can understand if you prefer not to merge this, since it may break in the future, but it does work.

Usage is simple: pass `customTemplate` to the component, where `customTemplate` is a string of HTML. The standard template is:

```javascript
'<div class="daterangepicker dropdown-menu">' +
  '<div class="calendar left">' +
      '<div class="daterangepicker_input">' +
        '<input class="input-mini form-control" type="text" name="daterangepicker_start" value="" />' +
        '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
        '<div class="calendar-time">' +
          '<div></div>' +
          '<i class="fa fa-clock-o glyphicon glyphicon-time"></i>' +
        '</div>' +
      '</div>' +
      '<div class="calendar-table"></div>' +
  '</div>' +
  '<div class="calendar right">' +
      '<div class="daterangepicker_input">' +
        '<input class="input-mini form-control" type="text" name="daterangepicker_end" value="" />' +
        '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
        '<div class="calendar-time">' +
          '<div></div>' +
          '<i class="fa fa-clock-o glyphicon glyphicon-time"></i>' +
        '</div>' +
      '</div>' +
      '<div class="calendar-table"></div>' +
  '</div>' +
  '<div class="ranges">' +
      '<div class="range_inputs">' +
          '<button class="applyBtn" disabled="disabled" type="button"></button> ' +
          '<button class="cancelBtn" type="button"></button>' +
      '</div>' +
  '</div>' +
'</div>';
```