### PR TITLE
fix: use this.import and add import polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    this.app.import('vendor/bootstrap-daterangepicker/daterangepicker.js');
-    this.app.import('vendor/bootstrap-daterangepicker/daterangepicker.css');
+    this.import('vendor/bootstrap-daterangepicker/daterangepicker.js');
+    this.import('vendor/bootstrap-daterangepicker/daterangepicker.css');
   },
 
   treeForVendor: function(vendorTree) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^5.2.4",
     "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-import-polyfill": "^0.2.0",
     "fastboot-transform": "^0.1.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,6 +1276,10 @@ ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@^1.1.1:
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
 
+ember-cli-import-polyfill@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz#c1a08a8affb45c97b675926272fe78cf4ca166f2"
+
 ember-cli-inject-live-reload@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.6.1.tgz#82b8f5be454815a75e7f6d42c9ce0bc883a914a3"


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-299929011
Should fix #50 

I'm unsure if it's the correct way to depend on the polyfill from inside the addon or if the consuming app should depend on the polyfill.