### PR TITLE
Ability to customize component

### DIFF
--- a/addon/templates/components/date-range-picker.hbs
+++ b/addon/templates/components/date-range-picker.hbs
@@ -1,8 +1,12 @@
-{{#if label}}
-  <label>{{label}}</label>
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  {{#if label}}
+    <label>{{label}}</label>
+  {{/if}}
+  {{input value=rangeText class=inputClasses placeholder=placeholder}}
+  <div class="hide">
+    {{input value=start}}
+    {{input value=end}}
+  </div>
 {{/if}}
-{{input value=rangeText class=inputClasses placeholder=placeholder}}
-<div class="hide">
-  {{input value=start}}
-  {{input value=end}}
-</div>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('with-params');
   this.route('without-params');
+  this.route('theme');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/theme.js
+++ b/tests/dummy/app/routes/theme.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,8 @@
 <div class="container">
   <h2 id="title">{{#link-to 'index'}}Ember Date Range Picker{{/link-to}}</h2>
   {{link-to 'With-Params' 'with-params'}} |
-  {{link-to 'Without-Params' 'without-params'}}
+  {{link-to 'Without-Params' 'without-params'}} |
+  {{link-to 'Theme' 'theme'}}
   <hr>
   {{outlet}}
 </div>

--- a/tests/dummy/app/templates/theme.hbs
+++ b/tests/dummy/app/templates/theme.hbs
@@ -1,0 +1,19 @@
+<h4>Route</h4>
+<div>
+  {{#date-range-picker
+    start="20140101"
+    end="20141231"
+    serverFormat="YYYYMMDD"
+   as |picker|}}
+    
+      <label>Awesome Form Label</label>
+      
+      <div class="input-group">
+        {{input value=rangeText class='daterangepicker-input form-control' placeholder=placeholder}}
+        <span class="input-group-btn">
+          <button class="btn btn-success" type="button">Search</button>
+        </span>
+      </div>
+
+  {{/date-range-picker}}
+</div>


### PR DESCRIPTION
One thing I've struggled with when using the date range picker is how to customize the component for our needs. There's already a PR open which allows you to change the way the drop down is rendered, but there's no easy way to do that for the actual rendered input, which is the main thing this PR is attempting to fix. 

Now in addition to being able to render a date range picker like so:

```
{{date-range-picker start="20140101" end="20141231" serverFormat="YYYYMMDD"}}
```

There is now also a version which takes a block:

```
{{#date-range-picker start="20140101" end="20141231" serverFormat="YYYYMMDD"}}
  ... do what you need here ...
{{/date-range-picker}}
```

The current state of this PR requires you to know what mark up to place inside to get everything to work but my thinking is that you would yield the components required along with anything else the outer component can supply, so in the end you'd be able to do the following to render with defaults:

```
{{#date-range-picker start="20140101" end="20141231" serverFormat="YYYYMMDD" as |picker|}}
  {{picker.input}}
{{/date-range-picker}}
```

Longer term I think it makes sense to take this approach further and deprecate the `label` option.

I'm opening this to start the conversation to see what appetite for the above changes would be before doing the work. 

Thanks!