### PR TITLE
Single picker fixes and autocomplete

### DIFF
--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -218,7 +218,7 @@ export default Component.extend({
         `${actionName} for date-range-picker must be a function`,
         typeof action === 'function'
       );
-      this.sendAction(actionName, start, end, picker);
+      this.get(actionName)(start, end, picker);
     } else {
       if (!this.isDestroyed) {
         this.setProperties({ start, end });

--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -37,7 +37,7 @@ export default Component.extend({
     if (!isEmpty(start) && !isEmpty(end)) {
       if (singleDatePicker) {
         return moment(start, serverFormat).format(format);
-      else {
+      } else {
         return moment(start, serverFormat).format(format) + this.get('separator') +
           moment(end, serverFormat).format(format);
       }

--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -44,6 +44,7 @@ export default Component.extend({
   separator: ' - ',
   singleDatePicker: false,
   placeholder: null,
+  autocomplete: 'off',
   containerClass: "form-group",
   inputClass: "form-control",
   inputClasses: computed('inputClass', function() {

--- a/addon/components/date-range-picker.js
+++ b/addon/components/date-range-picker.js
@@ -28,14 +28,19 @@ export default Component.extend({
   parentEl: 'body',
   format: 'MMM D, YYYY',
   serverFormat: 'YYYY-MM-DD',
-  rangeText: computed('start', 'end', function() {
+  rangeText: computed('start', 'end', 'singleDatePicker', function() {
     let format = this.get('format');
     let serverFormat = this.get('serverFormat');
     let start = this.get('start');
     let end = this.get('end');
+    let singleDatePicker = this.get('singleDatePicker');
     if (!isEmpty(start) && !isEmpty(end)) {
-      return moment(start, serverFormat).format(format) + this.get('separator') +
-        moment(end, serverFormat).format(format);
+      if (singleDatePicker) {
+        return moment(start, serverFormat).format(format);
+      else {
+        return moment(start, serverFormat).format(format) + this.get('separator') +
+          moment(end, serverFormat).format(format);
+      }
     }
     return '';
   }),

--- a/addon/templates/components/date-range-picker.hbs
+++ b/addon/templates/components/date-range-picker.hbs
@@ -4,5 +4,5 @@
   {{#if label}}
     <label class={{labelClass}}>{{label}}</label>
   {{/if}}
-  {{input value=rangeText class=inputClasses placeholder=placeholder}}
+  {{input value=rangeText class=inputClasses placeholder=placeholder autocomplete=autocomplete}}
 {{/if}}


### PR DESCRIPTION
We're in the process of switching our app to use daterangepicker, and I encountered a few minor issues with the add-on that I was able to resolve, as well a small enhancement. For the sake of brevity I included all three of these changes in the same PR, but I'm happy to separate them if needed. I've tested all of these updates locally. 

- When using the `singleDatePicker` property to only set a single date, rather than a range, the `rangeText` property was still showing two date values with the `separator`. I modified this property to only show the `start` value if `singleDatePicker` is true.

- I added an additional `autocomplete` parameter to the component, which sets the property on the input. In our app, the Chrome browser was showing previously entered dates in the autocomplete dropdown, which was getting in the way of the calendar. I assumed this was undesirable behavior, so I gave the property a default value of `"off"`. 

- Lastly, Ember 3.4 introduced a deprecation for the `sendAction` method, recommending that closure actions be used instead. I modified that method call inside of the `handleDateRangePickerEvent` method to directly call the method specified by `actionName`.
